### PR TITLE
Add gradient updating option and merge SVector and Number methods

### DIFF
--- a/src/soptimize.jl
+++ b/src/soptimize.jl
@@ -288,34 +288,34 @@ Bisection algorithm for finding the root ``f(x) ≈ 0`` within the initial brack
 
     which are tested for in the above order. Therefore, care should be taken not to make `wtol` too large.
 
-        """
-        function bisection(f, a::Real, b::Real; fa::Real = f(a), fb::Real = f(b),
-            ftol = √eps(), wtol = 0, maxiter = 100)
-            a, b = float(a), float(b)
-            @assert fa * fb ≤ 0 "initial values don't bracket zero"
-            @assert isfinite(a) && isfinite(b)
-            _bisection(f, float.(promote(a, b, fa, fb, ftol, wtol))..., maxiter)
+"""
+function bisection(f, a::Real, b::Real; fa::Real = f(a), fb::Real = f(b),
+    ftol = √eps(), wtol = 0, maxiter = 100)
+    a, b = float(a), float(b)
+    @assert fa * fb ≤ 0 "initial values don't bracket zero"
+    @assert isfinite(a) && isfinite(b)
+    _bisection(f, float.(promote(a, b, fa, fb, ftol, wtol))..., maxiter)
+end
+
+function _bisection(f, a, b, fa, fb, ftol, wtol, maxiter)
+    iter = 0
+    abs(fa) < ftol && return (x = a, fx = fa, isroot = true, iter = iter, ismaxiter = false)
+    abs(fb) < ftol && return (x = b, fx = fb, isroot = true, iter = iter, ismaxiter = false)
+    while true
+        iter += 1
+        m = middle(a, b)
+        fm = f(m)
+        abs(fm) < ftol && return (x = m, fx = fm, isroot = true, iter = iter, ismaxiter = false)
+        abs(b-a) ≤ wtol && return (x = m, fx = fm, isroot = false, iter = iter, ismaxiter = false)
+        if fa * fm > 0
+            a, fa = m, fm
+        else
+            b, fb = m, fm
         end
-
-        function _bisection(f, a, b, fa, fb, ftol, wtol, maxiter)
-            iter = 0
-            abs(fa) < ftol && return (x = a, fx = fa, isroot = true, iter = iter, ismaxiter = false)
-            abs(fb) < ftol && return (x = b, fx = fb, isroot = true, iter = iter, ismaxiter = false)
-            while true
-                iter += 1
-                m = middle(a, b)
-                fm = f(m)
-                abs(fm) < ftol && return (x = m, fx = fm, isroot = true, iter = iter, ismaxiter = false)
-                abs(b-a) ≤ wtol && return (x = m, fx = fm, isroot = false, iter = iter, ismaxiter = false)
-                if fa * fm > 0
-                    a, fa = m, fm
-                else
-                    b, fb = m, fm
-                end
-                iter == maxiter && return (x = m, fx = fm, isroot = false, iter = iter, ismaxiter = true)
-            end
-        end
+        iter == maxiter && return (x = m, fx = fm, isroot = false, iter = iter, ismaxiter = true)
+    end
+end
 
 
-        sroot(f, x::Number) = snewton(f, x)
-        sroot(f, x::Tuple{T, T}) where T <: Number = bisection(f, x[1], x[2])
+sroot(f, x::Number) = snewton(f, x)
+sroot(f, x::Tuple{T, T}) where T <: Number = bisection(f, x[1], x[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,10 @@ res = soptimize(rosenbrock, sx)
 @test res.g_converged == true
 @test rosenbrock(res.minimizer) == res.minimum
 @test show(res) === nothing
-
+res = soptimize(rosenbrock, sx, hguess = res.h)
+@test res.g_converged == true
+res = soptimize(rosenbrock, sx, updating = true)
+@test res.g_converged == true
 res = soptimize(rosenbrock, sx, StaticOptim.Order3())
 @test res.g_converged == true
 @test rosenbrock(res.minimizer) == res.minimum


### PR DESCRIPTION
With these changes, SVectors and Numbers are handled by the same method.
The updating option computes the gradient along with the function value after the initial proposal point. This is more efficient whenever the initial proposal is usually accepted, since computing the gradient is cheap.